### PR TITLE
Switch to GNU11

### DIFF
--- a/libc/Android.mk
+++ b/libc/Android.mk
@@ -549,7 +549,7 @@ endif
 
 # Define some common conlyflags
 libc_common_conlyflags := \
-    -std=gnu99
+    -std=gnu11
 
 # Define some common cppflags
 libc_common_cppflags := \


### PR DESCRIPTION
Why use a 16 year old version of c when we can use a 3 and a half year old version?
